### PR TITLE
Updated text on access screen for greater clarity

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 text-transform: uppercase; font-family: Arial, Helvetica, sans-serif; font-weight: 400; line-height: 1.5em; font-size: large; white-space: nowrap;
                 user-select: none; pointer-events: none;
             ">
-            Натисніть на екран для отримання доступу до WebAR-буклету «Телеграф Рональдса», 
+            Натисніть на екран, щоб почати перегляд WebAR-буклету <b>«Телеграф Рональдса»</b>
         </div>
     </div>
 


### PR DESCRIPTION
### Опис проблеми:
На початковому екрані для доступу до WebAR-буклету був некоректний або неінформативний текст.

### Кроки для відтворення багу:
1. Відкрити вебсторінку з WebAR-буклетом.
2. Звернути увагу на текст на екрані доступу.

### Очікувана поведінка:
Текст повинен чітко інформувати користувача про те, що потрібно натиснути на екран для початку перегляду.

### Фактична поведінка:
Текст не був достатньо інформативним і міг викликати плутанину серед користувачів.

### Рішення:
Я оновив текст на екрані доступу, щоб він чіткіше інформував користувача про необхідність натиснути на екран для початку перегляду WebAR-буклету.
